### PR TITLE
Fix the error of copy list property

### DIFF
--- a/EmitMapper.Core/Mappers/MapperForCollectionImpl.cs
+++ b/EmitMapper.Core/Mappers/MapperForCollectionImpl.cs
@@ -185,7 +185,7 @@ namespace EmitMapper.Mappers
         {
             var mi = typeof(MapperForCollectionImpl).GetMethod(
                copyMethodName,
-               BindingFlags.Instance | BindingFlags.Public
+               BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
             ).MakeGenericMethod(new Type[] { ExtractElementType(copiedObjectType) });
 
             return new AstReturn()


### PR DESCRIPTION
When the list field exists in the entity, an exception is thrown